### PR TITLE
phantomjs fails to start on macOS sierra

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,7 +59,7 @@
     "karma": "^0.13.14",
     "karma-chrome-launcher": "^0.2.1",
     "karma-jasmine": "^0.3.6",
-    "karma-phantomjs-launcher": "^0.2.1",
+    "karma-phantomjs-launcher": "^1.0.2",
     "karma-webpack": "^1.7.0",
     "phantomjs": "^1.9.18",
     "react-addons-test-utils": "^0.14.0",


### PR DESCRIPTION
phantomjs has issue with sierra (see karma issue [here](https://github.com/karma-runner/karma-phantomjs-launcher/issues/138)).  It's resolved with bumping the karma-phantomjs-launcher plugin to 1.0.2
