### PR TITLE
Clarify project status in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/pivotal/pulse.svg)](https://travis-ci.org/pivotal/pulse) [code climate] [![Join the chat at https://gitter.im/pivotal/new-project-monitor](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/pivotal/new-project-monitor?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://travis-ci.org/pivotal/pulse.svg)](https://travis-ci.org/pivotal/pulse) [![Join the chat at https://gitter.im/pivotal/new-project-monitor](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/pivotal/new-project-monitor?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 
 ## Table of Contents
@@ -9,13 +9,12 @@
 
 ## Description
 
-ProjectMonitor is a CI aggregator to help teams monitor the status of their builds.
+Pulse is a proposed React+Spring rewrite of [Project Monitor](https://github.com/pivotal/projectmonitor), a CI aggregator to help teams monitor the status of their builds.
+
 The project consists of 3 primary components:
 * Pulse CI Build API [postman](ci.pivotallabs.com)
 * [Pulse Management Tool](frontend/README.md)
 * Pulse Monitor Display [demo](ci.pivotallabs.com)
-
-![](https://d1fto35gcfffzn.cloudfront.net/images/labs/tools/project_monitor.png)
 
 The intent of pulse is to display the status of multiple Continuous Integration builds on a single web page.
 Displaying the status of all your projects' builds on a big screen monitor or TV provides a highly visible/glanceable resource
@@ -36,11 +35,6 @@ List of potential integrations:
 * Semaphore
 * Solano CI (formerly loved as tddium)
 * TeamCity
-
-We use Pulse internally at Pivotal Labs to display the status of the builds for all our client projects.
-We also have an instance of Pulse running at [ci.pivotallabs.com](ci.pivotallabs.com) that we use for displaying the status of the builds
-of various open source projects - both of projects Pivotal Labs maintains (such as Jasmine)
-and of non-Pivotal projects (such as Rails).
 
 ## Installation
 


### PR DESCRIPTION
In its current state, it's very confusing to stumble across this project and understand the relationship to the more feature-complete and actively developed [Project Monitor](https://github.com/pivotal/projectmonitor).

To fix that, I propose some changes to the README:
- Identify the project as a WIP
- Remove Project Monitor logo
- Remove link to ci.pivotallabs.com
